### PR TITLE
GRPC Streaming Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	github.com/dop251/goja v0.0.0-20230304130813-e2f543bf4b4c
 	github.com/golang/protobuf v1.5.3
 	github.com/jhump/protoreflect v1.15.0
+	github.com/mstoykov/k6-taskqueue-lib v0.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.2
-	go.k6.io/k6 v0.43.2-0.20230404074422-e40265226b89
+	go.k6.io/k6 v0.43.2-0.20230405123423-86ab12bd4272
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.2-0.20230222093303-bc1253ad3743
 	gopkg.in/guregu/null.v3 v3.5.0
@@ -52,7 +53,6 @@ require (
 	github.com/mccutchen/go-httpbin v1.1.2-0.20190116014521-c5cb2f4802fa // indirect
 	github.com/mstoykov/atlas v0.0.0-20220811071828-388f114305dd // indirect
 	github.com/mstoykov/envconfig v1.4.1-0.20220114105314-765c6d8c76f1 // indirect
-	github.com/mstoykov/k6-taskqueue-lib v0.1.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/onsi/gomega v1.27.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ go.buf.build/grpc/go/gogo/protobuf v1.4.9 h1:IaG7Rh/dtmoY1ZVJwSwyaGjQ8yb8emVMuX8
 go.buf.build/grpc/go/gogo/protobuf v1.4.9/go.mod h1:2rkC/lMWRLTLC2Bmn8BUP3ED9Kxx7FN3OHk+u7KCHDU=
 go.buf.build/grpc/go/prometheus/prometheus v1.4.4 h1:ddBWiMMWJsyqalhiUikpUwLsGZ18GqGCzsu8khG2mB4=
 go.buf.build/grpc/go/prometheus/prometheus v1.4.4/go.mod h1:QjrcwuvXQEp/Z0H21rmFvy4QTTnyWvfT5sffq/BlEJU=
-go.k6.io/k6 v0.43.2-0.20230404074422-e40265226b89 h1:aJSJixr/yPdHn7/bWP5sh1xrZMPJOjEYDgRNDS1sMbs=
-go.k6.io/k6 v0.43.2-0.20230404074422-e40265226b89/go.mod h1:Azozhj76R5Fa1pPatdrTgl7+cL5JHBTIqp4aWroBMw4=
+go.k6.io/k6 v0.43.2-0.20230405123423-86ab12bd4272 h1:ljt8asL1vKVDDbYTssH+bNlVnCAp1Sc7XUbdz6YVW5o=
+go.k6.io/k6 v0.43.2-0.20230405123423-86ab12bd4272/go.mod h1:Azozhj76R5Fa1pPatdrTgl7+cL5JHBTIqp4aWroBMw4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -445,3 +445,33 @@ func walkFileDescriptors(seen map[string]struct{}, fd *desc.FileDescriptor) []*d
 
 	return fds
 }
+
+// sanitizeMethodName
+func sanitizeMethodName(name string) string {
+	if name == "" {
+		return name
+	}
+
+	if !strings.HasPrefix(name, "/") {
+		name = "/" + name
+	}
+
+	return name
+}
+
+// getMethodDescriptor sanitize it, and gets GRPC method descriptor or an error if not found
+func (c *Client) getMethodDescriptor(method string) (protoreflect.MethodDescriptor, error) {
+	method = sanitizeMethodName(method)
+
+	if method == "" {
+		return nil, errors.New("method to invoke cannot be empty")
+	}
+
+	methodDesc := c.mds[method]
+
+	if methodDesc == nil {
+		return nil, fmt.Errorf("method %q not found in file descriptors", method)
+	}
+
+	return methodDesc, nil
+}

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -127,7 +127,7 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 
 		builtinMetrics: mi.vu.State().BuiltinMetrics,
 		done:           make(chan struct{}),
-		closeSend:      make(chan struct{}),
+		state:          opened,
 
 		writeQueueCh: make(chan message),
 

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -107,13 +107,6 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 	// should be something similar to the Invoke function
 	// in js/modules/k6/grpc/client.go
 
-	registerCallback := func() func(func() error) {
-		callback := mi.vu.RegisterCallback()
-		return func(f func() error) {
-			callback(f)
-		}
-	}
-
 	tagsAndMeta := mi.vu.State().Tags.GetCurrentValues()
 
 	s := &stream{
@@ -123,7 +116,7 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 		method:           methodName,
 		logger:           mi.vu.State().Logger,
 
-		tq: taskqueue.New(registerCallback),
+		tq: taskqueue.New(mi.vu.RegisterCallback),
 
 		builtinMetrics: mi.vu.State().BuiltinMetrics,
 		done:           make(chan struct{}),

--- a/grpc/listeners.go
+++ b/grpc/listeners.go
@@ -1,0 +1,92 @@
+package grpc
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+const (
+	eventData   = "data"
+	eventError  = "error"
+	eventEnd    = "end"
+	eventStatus = "status"
+)
+
+// eventListeners keeps track of the eventListeners for each event type
+type eventListeners struct {
+	data   *eventListener
+	error  *eventListener
+	end    *eventListener
+	status *eventListener
+}
+
+// eventListener keeps listeners of a certain type
+type eventListener struct {
+	eventType string
+
+	// this return goja.value *and* error in order to return error on exception instead of panic
+	// https://pkg.go.dev/github.com/dop251/goja#hdr-Functions
+	list []func(goja.Value) (goja.Value, error)
+}
+
+// newListener creates a new listener of a certain type
+func newListener(eventType string) *eventListener {
+	return &eventListener{
+		eventType: eventType,
+	}
+}
+
+// add adds a listener to the listener list
+func (l *eventListener) add(fn func(goja.Value) (goja.Value, error)) {
+	l.list = append(l.list, fn)
+}
+
+// getTypes return event listener of a certain type
+func (l *eventListeners) getType(t string) *eventListener {
+	switch t {
+	case eventData:
+		return l.data
+	case eventError:
+		return l.error
+	case eventStatus:
+		return l.status
+	case eventEnd:
+		return l.end
+	default:
+		return nil
+	}
+}
+
+// add adds a listener to the listeners
+func (l *eventListeners) add(t string, f func(goja.Value) (goja.Value, error)) error {
+	list := l.getType(t)
+
+	if list == nil {
+		return fmt.Errorf("unknown GRPC stream's event type: %s", t)
+	}
+
+	list.add(f)
+
+	return nil
+}
+
+// all returns all possible listeners for a certain event type or an empty array
+func (l *eventListeners) all(t string) []func(goja.Value) (goja.Value, error) {
+	list := l.getType(t)
+
+	if list == nil {
+		return []func(goja.Value) (goja.Value, error){}
+	}
+
+	return list.list
+}
+
+func newEventListeners() *eventListeners {
+	return &eventListeners{
+		data:   newListener(eventData),
+		error:  newListener(eventError),
+		status: newListener(eventStatus),
+		end:    newListener(eventEnd),
+	}
+}

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -1,0 +1,325 @@
+package grpc
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/dop251/goja"
+	"github.com/grafana/xk6-grpc/lib/netext/grpcext"
+	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
+	"github.com/sirupsen/logrus"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/metrics"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type message struct {
+	msg []byte
+}
+
+type stream struct {
+	vu     modules.VU
+	client *Client
+
+	logger logrus.FieldLogger
+
+	methodDescriptor protoreflect.MethodDescriptor
+
+	method string
+	stream *grpcext.Stream
+
+	tagsAndMeta    *metrics.TagsAndMeta
+	tq             *taskqueue.TaskQueue
+	builtinMetrics *metrics.BuiltinMetrics
+	obj            *goja.Object // the object that is given to js to interact with the stream
+
+	closeSend chan struct{}
+	done      chan struct{}
+
+	writeQueueCh chan message
+
+	eventListeners *eventListeners
+}
+
+// defineStream defines the goja.Object that is given to js to interact with the Stream
+func defineStream(rt *goja.Runtime, s *stream) {
+	must(rt, s.obj.DefineDataProperty(
+		"on", rt.ToValue(s.on), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+
+	must(rt, s.obj.DefineDataProperty(
+		"write", rt.ToValue(s.write), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+
+	must(rt, s.obj.DefineDataProperty(
+		"end", rt.ToValue(s.end), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE))
+}
+
+func (s *stream) beginStream() error {
+	req := &grpcext.StreamRequest{
+		Method:           s.method,
+		MethodDescriptor: s.methodDescriptor,
+	}
+
+	stream, err := s.client.conn.NewStream(s.vu.Context(), *req, metadata.MD{})
+	if err != nil {
+		return fmt.Errorf("failed to create a new stream: %w", err)
+	}
+	s.stream = stream
+
+	go s.loop()
+
+	return nil
+}
+
+func (s *stream) loop() {
+	ctx := s.vu.Context()
+	wg := new(sync.WaitGroup)
+
+	defer func() {
+		wg.Wait()
+		s.tq.Close()
+	}()
+
+	// read & write data from/to the stream
+	wg.Add(2)
+	go s.readData(wg)
+	go s.writeData(wg)
+
+	ctxDone := ctx.Done()
+	for {
+		select {
+		case <-ctxDone:
+			// VU is shutting down during an interrupt
+			// stream events will not be forwarded to the VU
+			s.tq.Queue(func() error {
+				return s.closeWithError(nil)
+			})
+			return
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *stream) queueMessage(msg map[string]interface{}) {
+	s.tq.Queue(func() error {
+		rt := s.vu.Runtime()
+		listeners := s.eventListeners.all(eventData)
+
+		for _, messageListener := range listeners {
+			if _, err := messageListener(rt.ToValue(msg)); err != nil {
+				// TODO(olegbespalov) consider logging the error
+				_ = s.closeWithError(err)
+
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// readData reads data from the stream and forward them to the readDataChan
+func (s *stream) readData(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for {
+		msg, err := s.stream.ReceiveConverted()
+
+		if err != nil && !isRegularClosing(err) {
+			s.logger.WithError(err).Debug("error while reading from the stream")
+
+			s.tq.Queue(func() error {
+				return s.closeWithError(err)
+			})
+
+			return
+		}
+
+		if len(msg) == 0 && isRegularClosing(err) {
+			s.logger.WithError(err).Debug("stream is cancelled/finished")
+
+			s.tq.Queue(func() error {
+				return s.closeWithError(nil)
+			})
+
+			return
+		}
+
+		s.queueMessage(msg)
+	}
+}
+
+func isRegularClosing(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, grpcext.ErrCanceled)
+}
+
+// writeData writes data to the stream
+func (s *stream) writeData(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	writeChannel := make(chan message)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case msg, ok := <-writeChannel:
+				if !ok {
+					return
+				}
+
+				err := s.stream.Send(msg.msg)
+				if err != nil {
+					s.logger.WithError(err).Error("failed to send data to the stream")
+
+					s.tq.Queue(func() error {
+						closeErr := s.closeWithError(err)
+						return closeErr
+					})
+					return
+				}
+			case _, ok := <-s.closeSend:
+				if !ok {
+					continue
+				}
+
+				if err := s.stream.CloseSend(); err != nil {
+					s.logger.WithError(err).Error("an error happened during stream closing")
+				}
+
+				close(s.closeSend)
+			case <-s.done:
+				return
+			}
+		}
+	}()
+
+	{
+		defer func() {
+			close(writeChannel)
+		}()
+
+		queue := make([]message, 0)
+		var wch chan message
+		var msg message
+
+		for {
+			wch = nil // this way if nothing to read it will just block
+			if len(queue) > 0 {
+				msg = queue[0]
+				wch = writeChannel
+			}
+			select {
+			case msg = <-s.writeQueueCh:
+				queue = append(queue, msg)
+			case wch <- msg:
+				queue = queue[:copy(queue, queue[1:])]
+
+			case <-s.done:
+				return
+			}
+		}
+	}
+}
+
+// on registers a listener for a certain event type
+func (s *stream) on(event string, listener func(goja.Value) (goja.Value, error)) {
+	if err := s.eventListeners.add(event, listener); err != nil {
+		s.vu.State().Logger.Warnf("can't register %s event handler: %s", event, err)
+	}
+}
+
+// write writes a message to the stream
+func (s *stream) write(input goja.Value) {
+	if input == nil || goja.IsNull(input) || goja.IsUndefined(input) {
+		s.logger.Warnf("can't send empty message")
+	}
+
+	rt := s.vu.Runtime()
+
+	b, err := input.ToObject(rt).MarshalJSON()
+	if err != nil {
+		s.logger.WithError(err).Warnf("can't marshal message")
+	}
+
+	s.writeQueueCh <- message{msg: b}
+}
+
+// end closes client the stream
+func (s *stream) end() {
+	var err error
+
+	defer func() {
+		_ = s.closeWithError(err)
+	}()
+
+	// send message only once
+	select {
+	case <-s.closeSend:
+		return
+	default:
+	}
+
+	s.closeSend <- struct{}{}
+
+	// TODO(olegbespalov): consider moving this somewhere closer to the stream closing
+	// that could happen even without calling end(), e.g. when server closes the stream
+	_ = s.callEventListeners(eventEnd)
+}
+
+func (s *stream) closeWithError(err error) error {
+	select {
+	case <-s.done:
+		s.logger.WithError(err).Debug("connection is already closed")
+		return nil
+	default:
+	}
+
+	close(s.done)
+
+	s.logger.WithError(err).Debug("connection closed")
+
+	if err != nil {
+		if errList := s.callErrorListeners(err); errList != nil {
+			return errList
+		}
+	}
+
+	return nil
+}
+
+func (s *stream) callErrorListeners(e error) error {
+	rt := s.vu.Runtime()
+
+	for _, errorListener := range s.eventListeners.all(eventError) {
+		// TODO(olegbespalov): consider wrapping the error into an object
+		// to provide more structure about error (like the error code and so on)
+
+		if _, err := errorListener(rt.ToValue(e)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *stream) callEventListeners(eventType string) error {
+	rt := s.vu.Runtime()
+
+	for _, listener := range s.eventListeners.all(eventType) {
+		if _, err := listener(rt.ToValue(struct{}{})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// must is a small helper that will panic if err is not nil.
+func must(rt *goja.Runtime, err error) {
+	if err != nil {
+		common.Throw(rt, err)
+	}
+}

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -210,9 +210,7 @@ func (s *stream) writeData(wg *sync.WaitGroup) {
 	}()
 
 	{
-		defer func() {
-			close(writeChannel)
-		}()
+		defer close(writeChannel)
 
 		queue := make([]message, 0)
 		var wch chan message
@@ -280,11 +278,8 @@ func (s *stream) end() {
 }
 
 func (s *stream) closeWithError(err error) error {
-	select {
-	case <-s.done:
-		s.logger.WithError(err).Debug("connection is already closed")
+	if s.state == closed {
 		return nil
-	default:
 	}
 
 	s.state = closed

--- a/grpc/tests/cmd_run_test.go
+++ b/grpc/tests/cmd_run_test.go
@@ -38,32 +38,32 @@ func TestGRPCInputOutput(t *testing.T) {
 		outputShouldContain    []string
 		outputShouldNotContain []string
 	}{
-		// "Server streaming": {
-		// 	script: "../../examples/grpc_server_streaming.js",
-		// 	outputShouldContain: []string{
-		// 		"output: -",
-		// 		"default: 1 iterations for each of 1 VUs",
-		// 		"1 complete and 0 interrupted iterations",
-		// 		"Found feature called",
-		// 	},
-		// 	outputShouldNotContain: []string{
-		// 		"Stream Error:",
-		// 	},
-		// },
-		// "Client Streaming": {
-		// 	script: "../../examples/grpc_client_streaming.js",
-		// 	outputShouldContain: []string{
-		// 		"output: -",
-		// 		"default: 1 iterations for each of 1 VUs",
-		// 		"1 complete and 0 interrupted iterations",
-		// 		"Visiting point",
-		// 		"Finished trip with 5 points",
-		// 		"Passed 5 feature",
-		// 	},
-		// 	outputShouldNotContain: []string{
-		// 		"Stream Error:",
-		// 	},
-		// },
+		"Server streaming": {
+			script: "../../examples/grpc_server_streaming.js",
+			outputShouldContain: []string{
+				"output: -",
+				"default: 1 iterations for each of 1 VUs",
+				"1 complete and 0 interrupted iterations",
+				"Found feature called",
+			},
+			outputShouldNotContain: []string{
+				"Stream Error:",
+			},
+		},
+		"Client Streaming": {
+			script: "../../examples/grpc_client_streaming.js",
+			outputShouldContain: []string{
+				"output: -",
+				"default: 1 iterations for each of 1 VUs",
+				"1 complete and 0 interrupted iterations",
+				"Visiting point",
+				"Finished trip with 5 points",
+				"Passed 5 feature",
+			},
+			outputShouldNotContain: []string{
+				"Stream Error:",
+			},
+		},
 		"Invoke": {
 			script: "../../examples/grpc_invoke.js",
 			outputShouldContain: []string{

--- a/lib/netext/grpcext/stream.go
+++ b/lib/netext/grpcext/stream.go
@@ -1,0 +1,122 @@
+package grpcext
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// Stream is the wrapper around the grpc.ClientStream
+// with some handy methods.
+type Stream struct {
+	method           string
+	methodDescriptor protoreflect.MethodDescriptor
+	raw              grpc.ClientStream
+	marshaler        protojson.MarshalOptions
+}
+
+// ErrCanceled canceled by client (k6)
+var ErrCanceled = errors.New("canceled by client (k6)")
+
+// ReceiveConverted receives a converted message from the stream
+// if the stream has been closed successfully, it returns io.EOF
+// if the stream has been cancelled, it returns ErrCanceled
+func (s *Stream) ReceiveConverted() (map[string]interface{}, error) {
+	raw, err := s.receive()
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	msg, errConv := s.convert(raw)
+	if errConv != nil {
+		return nil, errConv
+	}
+
+	return msg, err
+}
+
+func (s *Stream) receive() (*dynamicpb.Message, error) {
+	msg := dynamicpb.NewMessage(s.methodDescriptor.Output())
+	err := s.raw.RecvMsg(msg)
+
+	// io.EOF means that the stream has been closed successfully
+	if err == nil || errors.Is(err, io.EOF) {
+		return msg, err
+	}
+
+	sterr := status.Convert(err)
+	if sterr.Code() == codes.Canceled {
+		return nil, ErrCanceled
+	}
+
+	return nil, err
+}
+
+// convert converts the message to the map[string]interface{} format
+// which could be returned to the JS
+// there is a lot of marshaling/unmarshaling here, but if we just pass the dynamic message
+// the default Marshaller would be used, which would strip any zero/default values from the JSON.
+// eg. given this message:
+//
+//	message Point {
+//	   double x = 1;
+//		  double y = 2;
+//		  double z = 3;
+//	}
+//
+// and a value like this:
+// msg := Point{X: 6, Y: 4, Z: 0}
+// would result in JSON output:
+// {"x":6,"y":4}
+// rather than the desired:
+// {"x":6,"y":4,"z":0}
+func (s *Stream) convert(msg *dynamicpb.Message) (map[string]interface{}, error) {
+	// TODO(olegbespalov): add the test that checks that message is not nil
+
+	raw, err := s.marshaler.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the message: %w", err)
+	}
+
+	back := make(map[string]interface{})
+
+	err = json.Unmarshal(raw, &back)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the message: %w", err)
+	}
+
+	return back, err
+}
+
+// CloseSend closes the stream
+func (s *Stream) CloseSend() error {
+	return s.raw.CloseSend()
+}
+
+// BuildMessage builds a message from the input
+func (s *Stream) buildMessage(b []byte) (*dynamicpb.Message, error) {
+	msg := dynamicpb.NewMessage(s.methodDescriptor.Input())
+	if err := protojson.Unmarshal(b, msg); err != nil {
+		return nil, fmt.Errorf("can't serialise request object to protocol buffer: %w", err)
+	}
+
+	return msg, nil
+}
+
+// Send sends the message to the stream
+func (s *Stream) Send(b []byte) error {
+	msg, err := s.buildMessage(b)
+	if err != nil {
+		return err
+	}
+
+	return s.raw.SendMsg(msg)
+}


### PR DESCRIPTION
# What?

We are introducing GRPC streaming support, highly inspired by the xk6-websockets.

This is the base version, with the working (after `make build`) examples, but without the metrics and some other functionality (parameterization, metadata, and, for sure, tests) that will be introduced in the following PRs.

Trying to keep the PR smaller.

Note: original code of this repo was copied from the k6 with minor modifications.

Based on #4 

# Why?

The users request it.