### PR TITLE
GRPC Streams Metrics

### DIFF
--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -21,6 +21,7 @@ type (
 	ModuleInstance struct {
 		vu      modules.VU
 		exports map[string]interface{}
+		metrics *grpcMetrics
 	}
 )
 
@@ -37,9 +38,15 @@ func New() *RootModule {
 // NewModuleInstance implements the modules.Module interface to return
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	metrics, err := registerMetrics(vu.InitEnv().Registry)
+	if err != nil {
+		common.Throw(vu.Runtime(), fmt.Errorf("failed to register GRPC module metrics: %w", err))
+	}
+
 	mi := &ModuleInstance{
 		vu:      vu,
 		exports: make(map[string]interface{}),
+		metrics: metrics,
 	}
 
 	mi.exports["Client"] = mi.NewClient
@@ -119,6 +126,7 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 
 		tq: taskqueue.New(mi.vu.RegisterCallback),
 
+		grpcMetrics:    mi.metrics,
 		builtinMetrics: mi.vu.State().BuiltinMetrics,
 		done:           make(chan struct{}),
 		state:          opened,

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -21,7 +21,7 @@ type (
 	ModuleInstance struct {
 		vu      modules.VU
 		exports map[string]interface{}
-		metrics *grpcMetrics
+		metrics *instanceMetrics
 	}
 )
 
@@ -126,10 +126,10 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 
 		tq: taskqueue.New(mi.vu.RegisterCallback),
 
-		grpcMetrics:    mi.metrics,
-		builtinMetrics: mi.vu.State().BuiltinMetrics,
-		done:           make(chan struct{}),
-		state:          opened,
+		instanceMetrics: mi.metrics,
+		builtinMetrics:  mi.vu.State().BuiltinMetrics,
+		done:            make(chan struct{}),
+		state:           opened,
 
 		writeQueueCh: make(chan message),
 

--- a/grpc/metrics.go
+++ b/grpc/metrics.go
@@ -2,27 +2,27 @@ package grpc
 
 import "go.k6.io/k6/metrics"
 
-// grpcMetrics contains the metrics for the grpc extension.
-type grpcMetrics struct {
-	GRPCStreams                 *metrics.Metric
-	GRPCStreamsMessagesSent     *metrics.Metric
-	GRPCStreamsMessagesReceived *metrics.Metric
+// instanceMetrics contains the metrics for the grpc extension.
+type instanceMetrics struct {
+	Streams                 *metrics.Metric
+	StreamsMessagesSent     *metrics.Metric
+	StreamsMessagesReceived *metrics.Metric
 }
 
 // registerMetrics registers and returns the metrics in the provided registry
-func registerMetrics(registry *metrics.Registry) (*grpcMetrics, error) {
+func registerMetrics(registry *metrics.Registry) (*instanceMetrics, error) {
 	var err error
-	m := &grpcMetrics{}
+	m := &instanceMetrics{}
 
-	if m.GRPCStreams, err = registry.NewMetric("grpc_streams", metrics.Counter); err != nil {
+	if m.Streams, err = registry.NewMetric("grpc_streams", metrics.Counter); err != nil {
 		return nil, err
 	}
 
-	if m.GRPCStreamsMessagesSent, err = registry.NewMetric("grpc_streams_msgs_sent", metrics.Counter); err != nil {
+	if m.StreamsMessagesSent, err = registry.NewMetric("grpc_streams_msgs_sent", metrics.Counter); err != nil {
 		return nil, err
 	}
 
-	if m.GRPCStreamsMessagesReceived, err = registry.NewMetric("grpc_streams_msgs_received", metrics.Counter); err != nil {
+	if m.StreamsMessagesReceived, err = registry.NewMetric("grpc_streams_msgs_received", metrics.Counter); err != nil {
 		return nil, err
 	}
 

--- a/grpc/metrics.go
+++ b/grpc/metrics.go
@@ -1,0 +1,30 @@
+package grpc
+
+import "go.k6.io/k6/metrics"
+
+// grpcMetrics contains the metrics for the grpc extension.
+type grpcMetrics struct {
+	GRPCStreams                 *metrics.Metric
+	GRPCStreamsMessagesSent     *metrics.Metric
+	GRPCStreamsMessagesReceived *metrics.Metric
+}
+
+// registerMetrics registers and returns the metrics in the provided registry
+func registerMetrics(registry *metrics.Registry) (*grpcMetrics, error) {
+	var err error
+	m := &grpcMetrics{}
+
+	if m.GRPCStreams, err = registry.NewMetric("grpc_streams", metrics.Counter); err != nil {
+		return nil, err
+	}
+
+	if m.GRPCStreamsMessagesSent, err = registry.NewMetric("grpc_streams_msgs_sent", metrics.Counter); err != nil {
+		return nil, err
+	}
+
+	if m.GRPCStreamsMessagesReceived, err = registry.NewMetric("grpc_streams_msgs_received", metrics.Counter); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -72,10 +72,11 @@ func defineStream(rt *goja.Runtime, s *stream) {
 }
 
 func (s *stream) beginStream(p *callParams) error {
+	tags := s.vu.State().Tags.GetCurrentValues()
 	req := &grpcext.StreamRequest{
 		Method:           s.method,
 		MethodDescriptor: s.methodDescriptor,
-		TagsAndMeta:      &p.TagsAndMeta,
+		TagsAndMeta:      &tags,
 		Metadata:         p.Metadata,
 	}
 

--- a/grpc/tests/cmd_run_test.go
+++ b/grpc/tests/cmd_run_test.go
@@ -45,6 +45,9 @@ func TestGRPCInputOutput(t *testing.T) {
 				"default: 1 iterations for each of 1 VUs",
 				"1 complete and 0 interrupted iterations",
 				"Found feature called",
+				"grpc_streams",
+				"grpc_streams_msgs_received",
+				"grpc_streams_msgs_sent",
 			},
 			outputShouldNotContain: []string{
 				"Stream Error:",
@@ -59,6 +62,9 @@ func TestGRPCInputOutput(t *testing.T) {
 				"Visiting point",
 				"Finished trip with 5 points",
 				"Passed 5 feature",
+				"grpc_streams",
+				"grpc_streams_msgs_received",
+				"grpc_streams_msgs_sent",
 			},
 			outputShouldNotContain: []string{
 				"Stream Error:",
@@ -72,7 +78,11 @@ func TestGRPCInputOutput(t *testing.T) {
 				"1 complete and 0 interrupted iterations",
 				"3 Hasta Way, Newton, NJ 07860, USA",
 			},
-			outputShouldNotContain: []string{},
+			outputShouldNotContain: []string{
+				"grpc_streams",
+				"grpc_streams_msgs_received",
+				"grpc_streams_msgs_sent",
+			},
 		},
 		"Reflection": {
 			script: "../../examples/grpc_reflection.js",
@@ -82,7 +92,11 @@ func TestGRPCInputOutput(t *testing.T) {
 				"1 complete and 0 interrupted iterations",
 				"3 Hasta Way, Newton, NJ 07860, USA",
 			},
-			outputShouldNotContain: []string{},
+			outputShouldNotContain: []string{
+				"grpc_streams",
+				"grpc_streams_msgs_received",
+				"grpc_streams_msgs_sent",
+			},
 		},
 	}
 


### PR DESCRIPTION
# What?

This brings a few GRPC streams metrics to the module.

![image](https://github.com/grafana/xk6-grpc/assets/5425600/65b85790-2ed4-4790-acbf-ba20919fb637)

 :thinking:  Two questions to the reviewers:
* Currently, we also issue the `grpc_req_duration`, which also counts streams. Is that okay?
* Do you have in mind any other metrics that could be useful?

# Why?

Brings new metrics to the GRPC module and...

Resolves: #9 