### PR TITLE
Move `end` trigger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,8 @@ issues:
        - funlen
        - lll
    - linters:
-     - paralleltest # false positive: https://github.com/kunwardeep/paralleltest/issues/8.
-     text: "does not use range value in test Run"
+     - staticcheck
+     text: "The entire proto file grpc/reflection/v1alpha/reflection.proto is marked as deprecated."
    - linters:
      - forbidigo
      text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'

--- a/examples/grpc_client_streaming.js
+++ b/examples/grpc_client_streaming.js
@@ -84,6 +84,11 @@ export default () => {
     console.log('Stream Error: ' + err);
   });
 
+  stream.on('end', () => {
+    client.close();
+    console.log('All done');
+  })
+
   // send 5 random items
   for (var i = 0; i < 5; i++) {
     let point = DB[Math.floor(Math.random() * DB.length)];

--- a/examples/grpc_server_streaming.js
+++ b/examples/grpc_server_streaming.js
@@ -32,6 +32,7 @@ export default () => {
   stream.on('end', function () {
     // The server has finished sending
     client.close();
+    console.log('All done');
   });
 
   stream.on('error', function (e) {

--- a/grpc/tests/cmd_run_test.go
+++ b/grpc/tests/cmd_run_test.go
@@ -48,6 +48,7 @@ func TestGRPCInputOutput(t *testing.T) {
 				"grpc_streams",
 				"grpc_streams_msgs_received",
 				"grpc_streams_msgs_sent",
+				"All done",
 			},
 			outputShouldNotContain: []string{
 				"Stream Error:",
@@ -65,6 +66,7 @@ func TestGRPCInputOutput(t *testing.T) {
 				"grpc_streams",
 				"grpc_streams_msgs_received",
 				"grpc_streams_msgs_sent",
+				"All done",
 			},
 			outputShouldNotContain: []string{
 				"Stream Error:",


### PR DESCRIPTION
# What?

Moving the triggering of the end event to the stream close.

# Why?

That way, we guarantee that it will be executed after the closing of the stream.