### PR TITLE
Wrapping error into object

### DIFF
--- a/examples/grpc_client_streaming.js
+++ b/examples/grpc_client_streaming.js
@@ -81,7 +81,7 @@ export default () => {
   });
 
   stream.on('error', (err) => {
-    console.log('Stream Error: ' + err);
+    console.log('Stream Error: ' + JSON.stringify(err));
   });
 
   stream.on('end', () => {

--- a/examples/grpc_server_streaming.js
+++ b/examples/grpc_server_streaming.js
@@ -37,7 +37,7 @@ export default () => {
 
   stream.on('error', function (e) {
     // An error has occurred and the stream has been closed.
-    console.log('Error: ' + e);
+    console.log('Error: ' + JSON.stringify(e));
   });
 
   // send a message to the server

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -361,7 +361,7 @@ func (s *stream) callErrorListeners(e error) error {
 	return nil
 }
 
-type errorWrapper struct {
+type grpcError struct {
 	// Code is a gRPC error code.
 	Code codes.Code `json:"code"`
 	// Details is a list details attached to the error.
@@ -370,12 +370,17 @@ type errorWrapper struct {
 	Message string `json:"message"`
 }
 
+// Error to satisfy the error interface.
+func (e grpcError) Error() string {
+	return fmt.Sprintf("code: %d, message: %s", e.Code, e.Message)
+}
+
 // extractError tries to extract error information from an error.
 // If the error is not a gRPC error, it will be wrapped into a gRPC error.
-func extractError(e error) errorWrapper {
+func extractError(e error) grpcError {
 	grpcStatus := status.Convert(e)
 
-	w := errorWrapper{
+	w := grpcError{
 		Code:    grpcStatus.Code(),
 		Details: grpcStatus.Details(),
 		Message: grpcStatus.Message(),

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -15,6 +15,8 @@ import (
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/metrics"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -349,15 +351,42 @@ func (s *stream) closeWithError(err error) error {
 func (s *stream) callErrorListeners(e error) error {
 	rt := s.vu.Runtime()
 
-	for _, errorListener := range s.eventListeners.all(eventError) {
-		// TODO(olegbespalov): consider wrapping the error into an object
-		// to provide more structure about error (like the error code and so on)
+	obj := extractError(e)
 
-		if _, err := errorListener(rt.ToValue(e)); err != nil {
+	for _, errorListener := range s.eventListeners.all(eventError) {
+		if _, err := errorListener(rt.ToValue(obj)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+type errorWrapper struct {
+	// Code is a gRPC error code.
+	Code codes.Code `json:"code"`
+	// Details is a list details attached to the error.
+	Details []interface{} `json:"details"`
+	// Message is the original error message.
+	Message string `json:"message"`
+}
+
+// extractError tries to extract error information from an error.
+// If the error is not a gRPC error, it will be wrapped into a gRPC error.
+func extractError(e error) errorWrapper {
+	grpcStatus := status.Convert(e)
+
+	w := errorWrapper{
+		Code:    grpcStatus.Code(),
+		Details: grpcStatus.Details(),
+		Message: grpcStatus.Message(),
+	}
+
+	// fallback to the original error message
+	if w.Message == "" {
+		w.Message = e.Error()
+	}
+
+	return w
 }
 
 func (s *stream) callEventListeners(eventType string) error {

--- a/grpc/stream_test.go
+++ b/grpc/stream_test.go
@@ -101,6 +101,93 @@ func TestStream_RequestHeaders(t *testing.T) {
 	assert.Equal(t, registeredMetadata["x-load-tester"][0], "k6")
 }
 
+func TestStream_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+
+	stub := &FeatureExplorerStub{}
+
+	savedFeatures := []*grpcservice.Feature{
+		{
+			Name: "foo",
+			Location: &grpcservice.Point{
+				Latitude:  1,
+				Longitude: 2,
+			},
+		},
+		{
+			Name: "bar",
+			Location: &grpcservice.Point{
+				Latitude:  3,
+				Longitude: 4,
+			},
+		},
+	}
+
+	stub.listFeatures = func(rect *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+		for _, feature := range savedFeatures {
+			if err := stream.Send(feature); err != nil {
+				return err
+			}
+		}
+
+		return status.Error(codes.Internal, "lorem ipsum")
+	}
+
+	grpcservice.RegisterFeatureExplorerServer(ts.httpBin.ServerGRPC, stub)
+
+	replace := func(code string) (goja.Value, error) {
+		return ts.VU.Runtime().RunString(ts.httpBin.Replacer.Replace(code))
+	}
+
+	initString := codeBlock{
+		code: `
+		var client = new grpc.Client();
+		client.load([], "../grpc/testutils/grpcservice/route_guide.proto");`,
+	}
+	vuString := codeBlock{
+		code: `
+		client.connect("GRPCBIN_ADDR");
+		let stream = new grpc.Stream(client, "main.FeatureExplorer/ListFeatures")
+		stream.write({
+			lo: {
+			  latitude: 1,
+			  longitude: 2,
+			},
+			hi: {
+			  latitude: 1,
+			  longitude: 2,
+			},
+		});
+		stream.on('data', function (data) {
+			call('Feature:' + data.name);
+		})
+		stream.on('error', function (e) {
+			call('Code: ' + e.code + ' Message: ' + e.message);
+		});
+		`,
+	}
+
+	val, err := replace(initString.code)
+	assertResponse(t, initString, err, val, ts)
+
+	ts.ToVUContext()
+
+	val, err = replace(vuString.code)
+
+	ts.EventLoop.WaitOnRegistered()
+
+	assertResponse(t, vuString, err, val, ts)
+
+	assert.Equal(t, ts.callRecorder.Recorded(), []string{
+		"Feature:foo",
+		"Feature:bar",
+		"Code: 13 Message: lorem ipsum",
+	},
+	)
+}
+
 // FeatureExplorerStub is a stub for FeatureExplorerServer
 // it has ability to override methods
 type FeatureExplorerStub struct {


### PR DESCRIPTION
# What?

* Wrapping error to provide a better structure.
* Test error handling functionality.

# Why?

It's better for the end users.