### PR TITLE
Update golangci-linter & apply linter fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.51.2
+# v1.53.3
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m
@@ -10,7 +10,7 @@ issues:
   max-same-issues: 0
 
   # We want to try and improve the comments in the k6 codebase, so individual
-  # non-golint items from the default exclusion list will gradually be addded
+  # non-golint items from the default exclusion list will gradually be added
   # to the exclude-rules below
   exclude-use-default: false
 
@@ -25,7 +25,7 @@ issues:
        - funlen
        - lll
    - linters:
-     - staticcheck
+     - staticcheck # Tracked in https://github.com/grafana/xk6-grpc/issues/14
      text: "The entire proto file grpc/reflection/v1alpha/reflection.proto is marked as deprecated."
    - linters:
      - forbidigo
@@ -58,6 +58,7 @@ linters-settings:
       - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
       # Forbid everything in syscall except the uppercase constants
       - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
+      - '^logrus\.Logger$'
 
 linters:
   disable-all: true
@@ -68,7 +69,6 @@ linters:
     - bodyclose
     - contextcheck
     - cyclop
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/grpc/testutils/grpcservice/service.go
+++ b/grpc/testutils/grpcservice/service.go
@@ -23,7 +23,6 @@ import (
 // * https://grpc.io/docs/languages/go/quickstart/
 //
 //
-//nolint:lll
 //go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative route_guide.proto
 
 // FeatureExplorerImplementation contains an implementation of the FeatureExplorer service.
@@ -39,7 +38,7 @@ func NewFeatureExplorerServer(features ...*Feature) *FeatureExplorerImplementati
 }
 
 // GetFeature returns the feature at the given point.
-func (s *FeatureExplorerImplementation) GetFeature(ctx context.Context, point *Point) (*Feature, error) {
+func (s *FeatureExplorerImplementation) GetFeature(_ context.Context, point *Point) (*Feature, error) {
 	s.Logf("GetFeature called with: %+v\n", point)
 
 	n := rand.Intn(1000) //nolint:gosec

--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -228,7 +228,7 @@ type getServiceFileDescriptorMock struct {
 	nreqs int64
 }
 
-func (m *getServiceFileDescriptorMock) Send(req *reflectpb.ServerReflectionRequest) error {
+func (m *getServiceFileDescriptorMock) Send(_ *reflectpb.ServerReflectionRequest) error {
 	// TODO: check that the sent message is expected,
 	// otherwise return an error
 	return nil
@@ -318,7 +318,7 @@ message Empty {
 // invokemock is a mock for the grpc connection supporting only unary requests.
 type invokemock func(in, out *dynamicpb.Message, opts ...grpc.CallOption) error
 
-func (im invokemock) Invoke(ctx context.Context, url string, payload interface{}, reply interface{}, opts ...grpc.CallOption) error {
+func (im invokemock) Invoke(_ context.Context, _ string, payload interface{}, reply interface{}, opts ...grpc.CallOption) error {
 	in, ok := payload.(*dynamicpb.Message)
 	if !ok {
 		return fmt.Errorf("unexpected type for payload")
@@ -330,7 +330,7 @@ func (im invokemock) Invoke(ctx context.Context, url string, payload interface{}
 	return im(in, out, opts...)
 }
 
-func (invokemock) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+func (invokemock) NewStream(_ context.Context, _ *grpc.StreamDesc, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
# What?

Use the linter config from the k6 and apply linter fixes.

# Why?

Keep code "mergeable" to the k6 core.