### PR TITLE
[Experimental] Optional gRPC connection sharing among VUs

### DIFF
--- a/grpc/client.go
+++ b/grpc/client.go
@@ -502,27 +502,8 @@ func (c *Client) parseConnectParams(raw map[string]interface{}) (connectParams, 
 				return params, fmt.Errorf("invalid maxSendSize value: '%#v, it needs to be a positive integer", v)
 			}
 		case "connectionSharing":
-			var (
-				ok                    bool
-				connectionSharingBool bool
-			)
-
-			connectionSharingBool, ok = v.(bool)
-			if ok {
-				params.ConnectionSharing = 1
-				if connectionSharingBool {
-					params.ConnectionSharing = 100
-				}
-			} else {
-				params.ConnectionSharing, ok = v.(int64)
-				if !ok {
-					return params, fmt.Errorf("invalid connectionSharing value: '%#v', it needs to be boolean or a"+
-						" positive integer > 1", v)
-				}
-				if params.ConnectionSharing <= 1 {
-					return params, fmt.Errorf("invalid connectionSharing value: '%#v', it needs to be boolean or a"+
-						" positive integer > 1", v)
-				}
+			if err := parseConnectConnectionSharingParam(&params, v); err != nil {
+				return params, err
 			}
 		case "tls":
 			if err := parseConnectTLSParam(&params, v); err != nil {
@@ -533,6 +514,33 @@ func (c *Client) parseConnectParams(raw map[string]interface{}) (connectParams, 
 		}
 	}
 	return params, nil
+}
+
+func parseConnectConnectionSharingParam(params *connectParams, v interface{}) error {
+	var (
+		ok                    bool
+		connectionSharingBool bool
+	)
+
+	connectionSharingBool, ok = v.(bool)
+	if ok {
+		params.ConnectionSharing = 1
+		if connectionSharingBool {
+			params.ConnectionSharing = 100
+		}
+	} else {
+		params.ConnectionSharing, ok = v.(int64)
+		if !ok {
+			return fmt.Errorf("invalid connectionSharing value: '%#v', it needs to be boolean or a"+
+				" positive integer > 1", v)
+		}
+		if params.ConnectionSharing <= 1 {
+			return fmt.Errorf("invalid connectionSharing value: '%#v', it needs to be boolean or a"+
+				" positive integer > 1", v)
+		}
+	}
+
+	return nil
 }
 
 func parseConnectTLSParam(params *connectParams, v interface{}) error {

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -1027,7 +1027,7 @@ func TestClient_TlsParameters(t *testing.T) {
 				client.load([], "../vendor/go.k6.io/k6/lib/testutils/httpmultibin/grpc_testing/test.proto");`},
 			vuString: codeBlock{
 				code: fmt.Sprintf(`
-				client.connect("GRPCBIN_ADDR", { timeout: '2s', tls: { cacerts: ["%s"], cert: "%s", key: "%s" }});
+				client.connect("GRPCBIN_ADDR", { tls: { cacerts: ["%s"], cert: "%s", key: "%s" }});
 				var resp = client.invoke("grpc.testing.TestService/EmptyCall", {})
 				if (resp.status !== grpc.StatusOK) {
 					throw new Error("unexpected error: " + JSON.stringify(resp.error) + "or status: " + resp.status)


### PR DESCRIPTION
## What?

Add a parameter to `connectParams` that would allow `grpc.ClientConn`s to be shared across VUs. In order for connections to be shared (within a VU or across VUs) the following must be true:

1. A connection is eligible to be shared if a `Client` is `connect`ed with `{ connectionSharing: boolean|integer }`
2. A connection will only be shared with another `Client` (within a VU or across VUs) if the `addr` (address) parameter to `connect` is the same (case-insensitive)
3. The decision to permit a `Client`s connection to be shared is made when `connect` is called

Logically, it would only make sense to share a connection (within a VU or across VUs) if the two `Client`s in question target an endpoint that either:

1. Serves the same gRPC service
2. Multiplexes the gRPC services needed by both `Client`s

Aside from comparing `protoreflect.MethodDescriptor`s, I cannot think of a way to ensure the `Client`s should share a connection prior to making the connection and calling `invoke` (to generate the `protoreflect.MethodDescriptor` mapping). So it would be left to the test writer to decide if the `Client`s should share connections.

## Why?

This feature has the potential to substantially reduce the resources required for multiple VUs connecting to the same service(s) or endpoint(s). This gives greater flexibility for testing scenarios. 

On the other hand, this does _blur the line_ among VUs with `connectionSharing` enabled on `grpc.Client`s. There could potentially be unforeseen consequences to sharing connections among VUs. This situation, however, is mitigated by the fact that this feature is opt-in and disabled by default.

TODO / In-process:

- Limit the amount of sharing allowed by a single connection (via Latch or other such mechanism) to ensure a single gRPC connection does not exhaust the maximum permitted open channels on the server side
  - This would require the client to know at connection time what that maximum is and if not set, use a sane default: (typically 100)
  - This could also potentially introduce complicated connection management dealing with multiple shared, open connections across many VUs

### Connection sharing limiting

- The `ConnectionSharing` parameter can be either a boolean value OR an integer > 1
  - A `true` value will mean ConnectionSharing is enabled for the Client and the maximum sharing is set to a sane default (100)
    - This further means that the client's underlying connection will be shared with at most (100 - 1) clients 
  - A `false` value will mean ConnectionSharing is disabled entirely _for that Client_
  - An integer > 1 will mean ConnectionSharing is enabled for the Client and the underlying connection will be shared at most `connectionSharing - 1` number of times before a new connection is made.
  - It is important to note that the number of _shares_ a client's connection has depends solely on the value of the `connectionSharing` parameter exactly when the actual connection was dialed.

Limiting the number of connections can be a complicated concept. Since each `client.connect` can have a `connectionSharing` parameter with any arbitrary value for `connectionSharing` it can quickly become confusing which connections are possibly being shared.

## Checklist

- [x] Limit the connection sharing amount using a maximum connection sharing amount parameter and/or a sane default
- [x] Limit complexity of the connection sharing logic

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->
