### PR TITLE
chore: using of the k6's issue assigner

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,14 @@
+name: "Auto assign maintainer to issue"
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-user:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign k6's maintainer to issue
+        uses: grafana/k6/.github/actions/issue-assigner@master

--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -7,8 +7,5 @@ permissions:
   issues: write
 
 jobs:
-  assign-user:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Assign k6's maintainer to issue
-        uses: grafana/k6/.github/actions/issue-assigner@master
+  assign-maintainer:
+    uses: grafana/k6/.github/workflows/issue-auto-assign.yml@feat/make-auto-assigment-reusable


### PR DESCRIPTION
# What?

Using the issue auto assigner from https://github.com/grafana/k6/pull/3284

# Why?

That way, issues will be automatically assigned to one of the k6's maintainers.