### PR TITLE
Switch to the master branch since the PR was merged

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   assign-maintainer:
-    uses: grafana/k6/.github/workflows/issue-auto-assign.yml@feat/make-auto-assigment-reusable
+    uses: grafana/k6/.github/workflows/issue-auto-assign.yml@master


### PR DESCRIPTION
# What?

Switching the auto-assigner branch to the master since the k6's was merged https://github.com/grafana/k6/pull/3300

Related PR: https://github.com/grafana/xk6-grpc/pull/36

# Why?

The k6's feature branch no longer exists.