### PR TITLE
Support binary metadata

### DIFF
--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -336,6 +336,31 @@ func TestClient(t *testing.T) {
 			`},
 		},
 		{
+			name: "RequestBinHeaders",
+			initString: codeBlock{
+				code: `
+				var client = new grpc.Client();
+				client.load([], "../grpc/testdata/grpc_testing/test.proto");`,
+			},
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				tb.GRPCStub.EmptyCallFunc = func(ctx context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+					md, ok := metadata.FromIncomingContext(ctx)
+					if !ok || len(md["x-load-tester-bin"]) == 0 || md["x-load-tester-bin"][0] != string([]byte{2, 200}) {
+						return nil, status.Error(codes.FailedPrecondition, "")
+					}
+
+					return &grpc_testing.Empty{}, nil
+				}
+			},
+			vuString: codeBlock{code: `
+				client.connect("GRPCBIN_ADDR");
+				var resp = client.invoke("grpc.testing.TestService/EmptyCall", {}, { metadata: { "X-Load-Tester-bin": new Uint8Array([2, 200]) } })
+				if (resp.status !== grpc.StatusOK) {
+					throw new Error("failed to send correct headers in the request")
+				}
+			`},
+		},
+		{
 			name: "ResponseMessage",
 			initString: codeBlock{
 				code: `


### PR DESCRIPTION
# What?

Add support for binary metadata (postfixed with `-bin`).

This PR ports changes from the https://github.com/grafana/k6/pull/3234

# Why?

Closes: #43