### PR TITLE
Avoid closing the stream if server still open

### DIFF
--- a/examples/grpc_client_streaming.js
+++ b/examples/grpc_client_streaming.js
@@ -97,8 +97,6 @@ export default () => {
 
   // close the client stream
   stream.end();
-
-  sleep(1);
 };
 
 const pointSender = (stream, point) => {

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -131,7 +131,7 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 		instanceMetrics: mi.metrics,
 		builtinMetrics:  mi.vu.State().BuiltinMetrics,
 		done:            make(chan struct{}),
-		state:           opened,
+		writing:         opened,
 
 		writeQueueCh: make(chan message),
 

--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -131,7 +131,7 @@ func (mi *ModuleInstance) stream(c goja.ConstructorCall) *goja.Object {
 		instanceMetrics: mi.metrics,
 		builtinMetrics:  mi.vu.State().BuiltinMetrics,
 		done:            make(chan struct{}),
-		writing:         opened,
+		writingState:    opened,
 
 		writeQueueCh: make(chan message),
 

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -325,7 +325,7 @@ func (s *stream) end() {
 		return
 	}
 
-	s.logger.Debug("stream is closing")
+	s.logger.Debugf("finishing stream %s writing", s.method)
 
 	s.writingState = closed
 	s.writeQueueCh <- message{isClosing: true}
@@ -351,6 +351,7 @@ func (s *stream) close(err error) {
 	default:
 	}
 
+	s.logger.Debugf("stream %s is closing", s.method)
 	close(s.done)
 
 	s.tq.Queue(func() error {

--- a/grpc/stream_test.go
+++ b/grpc/stream_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/grafana/xk6-grpc/grpc/testutils/grpcservice"
@@ -184,6 +185,101 @@ func TestStream_ErrorHandling(t *testing.T) {
 		"Feature:foo",
 		"Feature:bar",
 		"Code: 13 Message: lorem ipsum",
+	},
+	)
+}
+
+// this test case is checking that everything that server sends
+// after the client finished (client.end called) is delivered to the client
+// and the end event is called
+func TestStream_ReceiveAllServerResponsesAfterEnd(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+
+	stub := &FeatureExplorerStub{}
+
+	savedFeatures := []*grpcservice.Feature{
+		{
+			Name: "foo",
+			Location: &grpcservice.Point{
+				Latitude:  1,
+				Longitude: 2,
+			},
+		},
+		{
+			Name: "bar",
+			Location: &grpcservice.Point{
+				Latitude:  3,
+				Longitude: 4,
+			},
+		},
+	}
+
+	stub.listFeatures = func(rect *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+		for _, feature := range savedFeatures {
+			// adding a delay to make server response "slower"
+			time.Sleep(200 * time.Millisecond)
+
+			if err := stream.Send(feature); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	grpcservice.RegisterFeatureExplorerServer(ts.httpBin.ServerGRPC, stub)
+
+	replace := func(code string) (goja.Value, error) {
+		return ts.VU.Runtime().RunString(ts.httpBin.Replacer.Replace(code))
+	}
+
+	initString := codeBlock{
+		code: `
+		var client = new grpc.Client();
+		client.load([], "../grpc/testutils/grpcservice/route_guide.proto");`,
+	}
+	vuString := codeBlock{
+		code: `
+		client.connect("GRPCBIN_ADDR");
+		let stream = new grpc.Stream(client, "main.FeatureExplorer/ListFeatures")
+		stream.on('data', function (data) {
+			call('Feature:' + data.name);
+		});
+		stream.on('end', function () {
+			call('End called');
+		});
+
+		stream.write({
+			lo: {
+			  latitude: 1,
+			  longitude: 2,
+			},
+			hi: {
+			  latitude: 1,
+			  longitude: 2,
+			},
+		});
+		stream.end();
+		`,
+	}
+
+	val, err := replace(initString.code)
+	assertResponse(t, initString, err, val, ts)
+
+	ts.ToVUContext()
+
+	val, err = replace(vuString.code)
+
+	ts.EventLoop.WaitOnRegistered()
+
+	assertResponse(t, vuString, err, val, ts)
+
+	assert.Equal(t, ts.callRecorder.Recorded(), []string{
+		"Feature:foo",
+		"Feature:bar",
+		"End called",
 	},
 	)
 }


### PR DESCRIPTION
# What?

In #29, it was reported that the server-side stream is prematurely closing when the client call `stream.end`. But the stream could still send the data.

So we do close the stream only when it closes (any error came, including the `io.EOF`)

To test the fix we, we just need to remove the sleep https://github.com/grafana/xk6-grpc/pull/47/commits/596304437f13d6abeff728cb3c2e3c933654f953

# Why?

Closes: #29