### PR TITLE
Inline omitting gosec's false positives

### DIFF
--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -265,14 +265,14 @@ func (s *stream) writeData(wg *sync.WaitGroup) {
 		for {
 			wch = nil // this way if nothing to read it will just block
 			if len(queue) > 0 {
-				msg = queue[0]
+				msg = queue[0] //nolint:gosec //false positive
 				wch = writeChannel
 			}
 			select {
 			case msg = <-s.writeQueueCh:
 				queue = append(queue, msg)
 			case wch <- msg:
-				queue = queue[:copy(queue, queue[1:])]
+				queue = queue[:copy(queue, queue[1:])] //nolint:gosec //false positive
 
 			case <-s.done:
 				return

--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -86,7 +86,7 @@ func TestConnInvokeInvalid(t *testing.T) {
 	var (
 		// valid arguments
 		ctx        = context.Background()
-		url        = "not-empty-url-for-method"
+		url        = "not-empty-url-for-method" //nolint:gosec //false positive
 		md         = metadata.New(nil)
 		methodDesc = methodFromProto("SayHello")
 		payload    = []byte(`{"greeting":"test"}`)


### PR DESCRIPTION
# What?

Fixing the linter noise like https://github.com/grafana/xk6-grpc/actions/runs/6767589517/job/18405810007

# Why?

CI is failing