### PR TITLE
Switching from direct afero usages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/jhump/protoreflect v1.15.3
 	github.com/mstoykov/k6-taskqueue-lib v0.1.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spf13/afero v1.1.2
 	github.com/stretchr/testify v1.8.4
 	go.k6.io/k6 v0.47.0
 	google.golang.org/grpc v1.58.3
@@ -64,6 +63,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
+	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/gjson v1.16.0 // indirect

--- a/grpc/tests/cmd_run_test.go
+++ b/grpc/tests/cmd_run_test.go
@@ -7,12 +7,12 @@ import (
 
 	_ "github.com/grafana/xk6-grpc"
 	"github.com/grafana/xk6-grpc/grpc/testutils"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cmd"
 	k6Tests "go.k6.io/k6/cmd/tests"
 	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/lib/fsext"
 )
 
 func getSingleFileTestState(tb testing.TB, script string, cliFlags []string, expExitCode exitcodes.ExitCode) *k6Tests.GlobalTestState {
@@ -21,7 +21,7 @@ func getSingleFileTestState(tb testing.TB, script string, cliFlags []string, exp
 	}
 
 	ts := k6Tests.NewGlobalTestState(tb)
-	require.NoError(tb, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), []byte(script), 0o644))
+	require.NoError(tb, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), []byte(script), 0o644))
 	ts.CmdArgs = append(append([]string{"k6", "run"}, cliFlags...), "test.js")
 	ts.ExpectedExitCode = int(expExitCode)
 
@@ -124,7 +124,7 @@ func TestGRPCInputOutput(t *testing.T) {
 				"GRPC_ADDR":       tb.Addr,
 				"GRPC_PROTO_PATH": "./proto.proto",
 			}
-			require.NoError(t, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, "proto.proto"), proto, 0o644))
+			require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "proto.proto"), proto, 0o644))
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 

--- a/grpc/teststate_test.go
+++ b/grpc/teststate_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/js/modulestest"
 	"go.k6.io/k6/lib"
@@ -104,13 +103,13 @@ func newTestState(t *testing.T) testState {
 
 	cwd, err := os.Getwd() //nolint:forbidigo
 	require.NoError(t, err)
-	fs := afero.NewOsFs()
+	fs := fsext.NewOsFs()
 
 	if isWindows {
 		fs = fsext.NewTrimFilePathSeparatorFs(fs)
 	}
 	testRuntime.VU.InitEnvField.CWD = &url.URL{Path: cwd}
-	testRuntime.VU.InitEnvField.FileSystems = map[string]afero.Fs{"file": fs}
+	testRuntime.VU.InitEnvField.FileSystems = map[string]fsext.Fs{"file": fs}
 
 	logger := logrus.New()
 	logger.SetLevel(logrus.InfoLevel)


### PR DESCRIPTION
# What?

We're switching from direct afero usage as part of https://github.com/grafana/k6/issues/1079

# Why?

As the long term we're planning to get rid of the afero, so it's good to use the wrapper right now