### PR TITLE
Warning that project is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # xk6-grpc
 
+> [!WARNING]  
+> Starting k6 version v0.49 the code of the `k6/x/grpc` extension is part of the `k6/net/grpc` of the [main k6 repository](https://github.com/grafana/k6). Please contribute and [open issues there](https://github.com/grafana/k6/issues). This repository is no longer maintained.
+
 This extension is re-designing of the k6's GRPC module that also should bring new features like GRPC streaming (it's available in the k6 as `k6/experimental/grpc`).
 
 The extension code copied from the original k6's GRPC module. The module documentation is available [here](https://k6.io/docs/javascript-api/k6-experimental/grpc/).

--- a/grpc/stream.go
+++ b/grpc/stream.go
@@ -265,14 +265,14 @@ func (s *stream) writeData(wg *sync.WaitGroup) {
 		for {
 			wch = nil // this way if nothing to read it will just block
 			if len(queue) > 0 {
-				msg = queue[0] //nolint:gosec //false positive
+				msg = queue[0]
 				wch = writeChannel
 			}
 			select {
 			case msg = <-s.writeQueueCh:
 				queue = append(queue, msg)
 			case wch <- msg:
-				queue = queue[:copy(queue, queue[1:])] //nolint:gosec //false positive
+				queue = queue[:copy(queue, queue[1:])]
 
 			case <-s.done:
 				return

--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -86,7 +86,7 @@ func TestConnInvokeInvalid(t *testing.T) {
 	var (
 		// valid arguments
 		ctx        = context.Background()
-		url        = "not-empty-url-for-method" //nolint:gosec //false positive
+		url        = "not-empty-url-for-method"
 		md         = metadata.New(nil)
 		methodDesc = methodFromProto("SayHello")
 		payload    = []byte(`{"greeting":"test"}`)


### PR DESCRIPTION
# What?

This change adds a warning to the repository, explaining that the project's code was back-merged to the core.

Also, it contains a revert commit of the inline `no-lint` omission. Otherwise, the linter stage will fail to pass.

I'm also going to archive the repository after the k6 v0.49 release.

# Why?

It's essential to point users to the correct place for contributions.